### PR TITLE
[PLA-553] Feat: Add role breakdown to moodle_users_online

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 A local plugin that presents an endpoint for Prometheus metric gathering.
 Can be used either in Prometheus or as an InfluxDB v2 scraper
 
+## Features
+- **Online users by role**: The `moodle_users_online` metric now includes optional per-role breakdowns using a `role` label (e.g., `role="student"`, `role="teacher"`). The total count (without labels) is still exposed for backward compatibility.
+- **Configurable**: Default online window, role priority list, context filtering (system/course/category), and cache TTL are all configurable via plugin settings.
+- **Lightweight caching**: Role-based counts are cached using Moodle's cache API to minimize database load on high-traffic sites.
+
+## Configuration
+Navigate to **Site administration > Plugins > Local plugins > Prometheus reporting endpoint** to configure:
+- **Default online window**: Time window (seconds) to consider a user online. Can be overridden by the `timeframe` URL parameter.
+- **Roles to track**: Comma-separated list of role shortnames (e.g., `editingteacher,teacher,student`). Order defines priority if a user has multiple roles.
+- **Contexts to check**: System, category, and/or course contexts to search for role assignments.
+- **Cache TTL**: How long (seconds) to cache online-by-role counts. Set to 0 to disable caching.
+
 ## Developing
 Plugins can add their own metrics to the output by adding their own `plugin_name_prometheus_get_metrics(int $window)` function
 to lib.php. This function **must** return either one or more `\local_prometheus\metric` objects, or an empty array.

--- a/db/caches.php
+++ b/db/caches.php
@@ -15,7 +15,7 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Prometheus reporting endpoint for Moodle
+ * Cache definitions for local_prometheus
  *
  * @package     local_prometheus
  * @copyright   2023 University of Essex
@@ -25,7 +25,13 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2025110700;
-$plugin->requires  = 2019051100;
-$plugin->component = 'local_prometheus';
-$plugin->release   = 'v1.2.0';
+$definitions = [
+    'usersonlinebyrole' => [
+        'mode' => cache_store::MODE_APPLICATION,
+        'simplekeys' => true,
+        'simpledata' => false,
+        'staticacceleration' => true,
+        'staticaccelerationsize' => 1,
+    ],
+];
+

--- a/lang/en/local_prometheus.php
+++ b/lang/en/local_prometheus.php
@@ -58,6 +58,22 @@ $string['activitystatistics:description'] = 'Include the number of recent entrie
 $string['extratags'] = 'Extra tags for each metric';
 $string['extratags:description'] = 'Include extra tags to be included in each metric. Each key=value pair should be on a separate line. Keys and values should be separated by an \'=\' equals.';
 
+$string['heading:onlineusers'] = 'Online users by role';
+$string['heading:onlineusers:information'] = 'Configure how online users are counted and broken down by role';
+
+$string['onlinewindow'] = 'Default online window (seconds)';
+$string['onlinewindow:description'] = 'Default time window (in seconds) for considering a user online. Can be overridden by the <var>timeframe</var> URL parameter.';
+$string['onlineroles'] = 'Roles to track';
+$string['onlineroles:description'] = 'Comma-separated list of role shortnames to track for online users. Order defines priority: if a user has multiple roles, they will be counted under the first matching role in this list.';
+$string['onlinecontexts'] = 'Contexts to check';
+$string['onlinecontexts:description'] = 'Which contexts to check when assigning users to roles. System context typically includes admins, course context includes teachers and students.';
+$string['onlinecachettl'] = 'Cache TTL (seconds)';
+$string['onlinecachettl:description'] = 'How long to cache online user counts by role (in seconds) to reduce database load. Set to 0 to disable caching.';
+
+$string['context:system'] = 'System';
+$string['context:coursecat'] = 'Category';
+$string['context:course'] = 'Course';
+
 $string['metric:onlineusers'] = 'Number of currently online users';
 $string['metric:activeusers'] = 'Number of current active users (not deleted or suspended)';
 $string['metric:deletedusers'] = 'Number of deleted users';

--- a/metrics.php
+++ b/metrics.php
@@ -38,7 +38,8 @@ $token = $tokenauthenabled
     ? optional_param('token', '', PARAM_BASE64)
     : required_param('token', PARAM_BASE64);
 
-$timeframe = optional_param('timeframe', 60 * 5, PARAM_INT);
+$defaultwindow = get_config('local_prometheus', 'onlinewindow') ?: 300;
+$timeframe = optional_param('timeframe', $defaultwindow, PARAM_INT);
 
 $cutoff = time() - $timeframe;
 

--- a/settings.php
+++ b/settings.php
@@ -96,5 +96,44 @@ if ($hassiteconfig) {
         ));
     }
 
+    // Online users by role settings.
+    $settings->add(new admin_setting_heading('local_prometheus_onlineusers',
+        get_string('heading:onlineusers', 'local_prometheus'),
+        get_string('heading:onlineusers:information', 'local_prometheus')
+    ));
+
+    $settings->add(new admin_setting_configtext('local_prometheus/onlinewindow',
+        get_string('onlinewindow', 'local_prometheus'),
+        get_string('onlinewindow:description', 'local_prometheus'),
+        300,
+        PARAM_INT
+    ));
+
+    $settings->add(new admin_setting_configtext('local_prometheus/onlineroles',
+        get_string('onlineroles', 'local_prometheus'),
+        get_string('onlineroles:description', 'local_prometheus'),
+        'editingteacher,teacher,student',
+        PARAM_TEXT
+    ));
+
+    $contextoptions = [
+        CONTEXT_SYSTEM => get_string('context:system', 'local_prometheus'),
+        CONTEXT_COURSECAT => get_string('context:coursecat', 'local_prometheus'),
+        CONTEXT_COURSE => get_string('context:course', 'local_prometheus')
+    ];
+    $settings->add(new admin_setting_configmultiselect('local_prometheus/onlinecontexts',
+        get_string('onlinecontexts', 'local_prometheus'),
+        get_string('onlinecontexts:description', 'local_prometheus'),
+        [CONTEXT_SYSTEM, CONTEXT_COURSE],
+        $contextoptions
+    ));
+
+    $settings->add(new admin_setting_configtext('local_prometheus/onlinecachettl',
+        get_string('onlinecachettl', 'local_prometheus'),
+        get_string('onlinecachettl:description', 'local_prometheus'),
+        30,
+        PARAM_INT
+    ));
+
     $ADMIN->add('localplugins', $settings);
 }


### PR DESCRIPTION
Add configurable per-role breakdown to moodle_users_online metric:
- Keep total series without labels (backward compatibility)
- Add role-labeled series (e.g., role="student", role="teacher")
- Configurable role priority, contexts (system/course/category), and cache TTL
- Implement MUC-backed caching to reduce DB load
- Default: editingteacher > teacher > student, 300s window, 30s cache

Changes:
- Add settings for online window, roles CSV, contexts multiselect, cache TTL
- Create db/caches.php for usersonlinebyrole cache area
- Implement local_prometheus_get_online_users_by_role() with priority logic
- Update metrics.php to use configured default window
- Document new features in README.md
- Bump version to 2025110700 (v1.2.0)

PLA-553